### PR TITLE
feat(gin): add whitespace parser for inverted index

### DIFF
--- a/be/src/storage/index/inverted/clucene/clucene_inverted_util.h
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_util.h
@@ -33,6 +33,8 @@ StatusOr<std::unique_ptr<lucene::analysis::Analyzer>> get_analyzer(InvertedIndex
         chinese_analyzer->setStem(false);
         return chinese_analyzer;
     }
+    case InvertedIndexParserType::PARSER_WHITESPACE:
+        return std::make_unique<lucene::analysis::WhitespaceAnalyzer>();
     default:
         return Status::NotSupported("Not support UNKNOWN parser_type");
     }

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_writer.cpp
@@ -94,6 +94,8 @@ public:
             auto chinese_analyzer = _CLNEW lucene::analysis::LanguageBasedAnalyzer();
             chinese_analyzer->setLanguage(L"cjk");
             _analyzer.reset(chinese_analyzer);
+        } else if (_parser_type == InvertedIndexParserType::PARSER_WHITESPACE) {
+            _analyzer = std::make_unique<lucene::analysis::WhitespaceAnalyzer>();
         } else {
             // ANALYSER_NOT_SET, ANALYSER_NONE use default SimpleAnalyzer
             _analyzer = std::make_unique<lucene::analysis::SimpleAnalyzer>();
@@ -132,7 +134,8 @@ public:
 
                 if (_parser_type == InvertedIndexParserType::PARSER_ENGLISH ||
                     _parser_type == InvertedIndexParserType::PARSER_CHINESE ||
-                    _parser_type == InvertedIndexParserType::PARSER_STANDARD) {
+                    _parser_type == InvertedIndexParserType::PARSER_STANDARD ||
+                    _parser_type == InvertedIndexParserType::PARSER_WHITESPACE) {
                     _char_string_reader->init(tchar.c_str(), tchar.size(), false);
                     auto stream = _analyzer->reusableTokenStream(_field->name(), _char_string_reader.get());
                     _field->setValue(stream);
@@ -157,7 +160,8 @@ public:
             for (int i = 0; i < count; ++i) {
                 if (_parser_type == InvertedIndexParserType::PARSER_ENGLISH ||
                     _parser_type == InvertedIndexParserType::PARSER_CHINESE ||
-                    _parser_type == InvertedIndexParserType::PARSER_STANDARD) {
+                    _parser_type == InvertedIndexParserType::PARSER_STANDARD ||
+                    _parser_type == InvertedIndexParserType::PARSER_WHITESPACE) {
                     _char_string_reader->init(data, 0, false);
                     auto stream = _analyzer->reusableTokenStream(_field->name(), _char_string_reader.get());
                     _field->setValue(stream);

--- a/be/src/storage/index/inverted/inverted_index_common.h
+++ b/be/src/storage/index/inverted/inverted_index_common.h
@@ -29,6 +29,7 @@ enum class InvertedIndexParserType {
     PARSER_STANDARD = 2,
     PARSER_ENGLISH = 3,
     PARSER_CHINESE = 4,
+    PARSER_WHITESPACE = 5,
 };
 
 const std::string INVERTED_IMP_KEY = "imp_lib";
@@ -39,6 +40,7 @@ const std::string INVERTED_INDEX_PARSER_NONE = "none";
 const std::string INVERTED_INDEX_PARSER_STANDARD = "standard";
 const std::string INVERTED_INDEX_PARSER_ENGLISH = "english";
 const std::string INVERTED_INDEX_PARSER_CHINESE = "chinese";
+const std::string INVERTED_INDEX_PARSER_WHITESPACE = "whitespace";
 const std::string LIKE_FN_NAME = "like";
 
 const std::string INVERTED_INDEX_TOKENIZED_KEY = "tokenized";

--- a/be/src/storage/index/inverted/inverted_index_option.cpp
+++ b/be/src/storage/index/inverted/inverted_index_option.cpp
@@ -42,6 +42,8 @@ std::string inverted_index_parser_type_to_string(InvertedIndexParserType parser_
         return INVERTED_INDEX_PARSER_ENGLISH;
     case InvertedIndexParserType::PARSER_CHINESE:
         return INVERTED_INDEX_PARSER_CHINESE;
+    case InvertedIndexParserType::PARSER_WHITESPACE:
+        return INVERTED_INDEX_PARSER_WHITESPACE;
     default:
         return INVERTED_INDEX_PARSER_UNKNOWN;
     }
@@ -57,6 +59,8 @@ InvertedIndexParserType get_inverted_index_parser_type_from_string(const std::st
         return InvertedIndexParserType::PARSER_ENGLISH;
     } else if (lower_value == INVERTED_INDEX_PARSER_CHINESE) {
         return InvertedIndexParserType::PARSER_CHINESE;
+    } else if (lower_value == INVERTED_INDEX_PARSER_WHITESPACE) {
+        return InvertedIndexParserType::PARSER_WHITESPACE;
     }
 
     return InvertedIndexParserType::PARSER_UNKNOWN;

--- a/docs/en/table_design/indexes/inverted_index.md
+++ b/docs/en/table_design/indexes/inverted_index.md
@@ -16,7 +16,7 @@ The full-text inverted index is not yet supported in Primary Key tables and shar
 
 ## Overview
 
-StarRocks stores its underlying data in the data files organized by columns. Each data file contains the full-text inverted index based on the indexed columns. The values in the indexed columns are tokenized into individual words. Each word after tokenization is treated as an index entry, mapping to the row number where the word appears. Currently supported tokenization methods for English tokenization, Chinese tokenization, multilingual tokenization, and no tokenization.
+StarRocks stores its underlying data in the data files organized by columns. Each data file contains the full-text inverted index based on the indexed columns. The values in the indexed columns are tokenized into individual words. Each word after tokenization is treated as an index entry, mapping to the row number where the word appears. Currently supported tokenization methods for English tokenization, Chinese tokenization, multilingual tokenization, whitespace tokenization, and no tokenization.
 
 For example, if a data row contains "hello world" and its row number is 123, the full-text inverted index builds index entries based on this tokenization result and row number: hello->123, world->123.
 
@@ -56,6 +56,7 @@ PROPERTIES (
   - `english`: English tokenization. This tokenization method typically tokenizing at any non-alphabetic character. Also, uppercase English letters are converted to lowercase. Therefore, keywords in the query conditions need to be lowercase English rather than uppercase English to leverage the full-text inverted index to locate data rows.
   - `chinese`: Chinese tokenization. This tokenization method uses the [CJK Analyzer](https://lucene.apache.org/core/6_6_1/analyzers-common/org/apache/lucene/analysis/cjk/package-summary.html) in CLucene for tokenization.
   - `standard`: Multilingual tokenization. This tokenization method provides grammar based tokenization (based on the [Unicode Text Segmentation algorithm](https://unicode.org/reports/tr29/)) and works well for most languages and cases of mixed languages, such as Chinese and English. For example, this tokenization method can distinguishes between Chinese and English when these two languages coexist. After tokenizing English, it converts uppercase English letters to lowercase. Therefore, keywords in the query conditions need to be lowercase English rather than uppercase English to leverage the full-text inverted index to locate data rows.
+  - `whitespace`: Whitespace tokenization. This tokenization method splits text into tokens only at whitespace characters, preserving punctuation and special characters within tokens. Unlike the `english` and `standard` tokenizers, this method does not perform lowercasing, so queries are case-sensitive. This is useful for indexing data like email addresses, URLs, or hyphenated identifiers where punctuation is meaningful and should not be used as a token boundary. This is a well-established tokenizer also available in Apache Lucene, Solr, and Elasticsearch.
 - The data type of the indexed column must be CHAR, VARCHAR, or STRING.
 
 #### Add full-text inverted index after table creation
@@ -92,7 +93,7 @@ After creating a full-text inverted index, you need to ensure that the system va
 
 #### Supported queries when indexed column is tokenized
 
-If the full-text inverted index tokenizes indexed columns, that is, `'parser' = 'standard|english|chinese'`, only the `MATCH` predicate is supported for data filtering using full-text inverted indexes, and the format needs to be `<col_name> (NOT) MATCH '%keyword%'`. The `keyword` must be a string literal, and does not support expressions .
+If the full-text inverted index tokenizes indexed columns, that is, `'parser' = 'standard|english|chinese|whitespace'`, only the `MATCH` predicate is supported for data filtering using full-text inverted indexes, and the format needs to be `<col_name> (NOT) MATCH '%keyword%'`. The `keyword` must be a string literal, and does not support expressions .
 
 1. Create a table and insert a few rows of test data.
 
@@ -148,7 +149,7 @@ If the full-text inverted index tokenizes indexed columns, that is, `'parser' = 
     Empty set (0.02 sec)
     ```
 
-- If English or multilingual tokenization is used to construct the full-text inverted index, uppercase English words are converted to lowercase when the full-text inverted index is actually stored. Therefore, during queries, keywords need to be lowercase instead of uppercase to utilize the full-text inverted index to locate data rows.
+- If English or multilingual tokenization is used to construct the full-text inverted index, uppercase English words are converted to lowercase when the full-text inverted index is actually stored. Therefore, during queries, keywords need to be lowercase instead of uppercase to utilize the full-text inverted index to locate data rows. Note that whitespace tokenization does not perform lowercasing, so queries are case-sensitive (e.g., `"Hello"` and `"hello"` are different tokens).
 
     ```SQL
     MySQL [example_db]> INSERT INTO t VALUES (3, "StarRocks is the BEST");

--- a/docs/zh/table_design/indexes/inverted_index.md
+++ b/docs/zh/table_design/indexes/inverted_index.md
@@ -16,7 +16,7 @@ import Beta from '../../_assets/commonMarkdown/_beta.mdx'
 
 ## 概述
 
-StarRocks 将其底层数据存储在按列组织的数据文件中。每个数据文件包含基于索引列的全文倒排索引。索引列中的值被分词为单个词。分词后的每个词被视为一个索引条目，映射到该词出现的行号。目前支持的分词方法包括英文分词、中文分词、多语言分词和不分词。
+StarRocks 将其底层数据存储在按列组织的数据文件中。每个数据文件包含基于索引列的全文倒排索引。索引列中的值被分词为单个词。分词后的每个词被视为一个索引条目，映射到该词出现的行号。目前支持的分词方法包括英文分词、中文分词、多语言分词、空白字符分词和不分词。
 
 例如，如果一行数据包含 "hello world" 且其行号为 123，全文倒排索引根据分词结果和行号构建索引条目：hello->123, world->123。
 
@@ -56,6 +56,7 @@ PROPERTIES (
   - `english`: 英文分词。此分词方法通常在任何非字母字符处进行分词。此外，大写英文字符会被转换为小写。因此，查询条件中的关键词需要是小写英文而不是大写英文，以利用全文倒排索引定位数据行。
   - `chinese`: 中文分词。此分词方法使用 CLucene 中的 [CJK Analyzer](https://lucene.apache.org/core/6_6_1/analyzers-common/org/apache/lucene/analysis/cjk/package-summary.html) 进行分词。
   - `standard`: 多语言分词。此分词方法提供基于语法的分词（基于 [Unicode Text Segmentation algorithm](https://unicode.org/reports/tr29/)），适用于大多数语言和混合语言的情况，如中英文。例如，此分词方法可以区分中英文。当中英文共存时，分词后会将大写英文字符转换为小写。因此，查询条件中的关键词需要是小写英文而不是大写英文，以利用全文倒排索引定位数据行。
+  - `whitespace`: 空白字符分词。此分词方法仅在空白字符处将文本拆分为标记，保留标记内的标点符号和特殊字符。与 `english` 和 `standard` 分词器不同，此方法不执行小写转换，因此查询区分大小写。适用于索引电子邮件地址、URL 或带连字符的标识符等数据，这些数据中的标点符号具有语义意义，不应作为标记边界。这是一种成熟的分词器，在 Apache Lucene、Solr 和 Elasticsearch 中也可用。
 - 索引列的数据类型必须是 CHAR、VARCHAR 或 STRING。
 
 #### 在创建表后添加全文倒排索引
@@ -92,7 +93,7 @@ ALTER TABLE t DROP index idx;
 
 #### 当索引列已分词时支持的查询
 
-如果全文倒排索引对索引列进行了分词，即 `'parser' = 'standard|english|chinese'`，则仅支持使用 `MATCH` 谓词进行数据过滤，格式需为 `<col_name> (NOT) MATCH '%keyword%'`。`keyword` 必须是字符串字面量，不支持表达式。
+如果全文倒排索引对索引列进行了分词，即 `'parser' = 'standard|english|chinese|whitespace'`，则仅支持使用 `MATCH` 谓词进行数据过滤，格式需为 `<col_name> (NOT) MATCH '%keyword%'`。`keyword` 必须是字符串字面量，不支持表达式。
 
 1. 创建一个表并插入几行测试数据。
 
@@ -148,7 +149,7 @@ ALTER TABLE t DROP index idx;
     Empty set (0.02 sec)
     ```
 
-- 如果使用英文或多语言分词构建全文倒排索引，存储时会将大写英文单词转换为小写。因此，在查询时，关键词需要是小写而不是大写，以利用全文倒排索引定位数据行。
+- 如果使用英文或多语言分词构建全文倒排索引，存储时会将大写英文单词转换为小写。因此，在查询时，关键词需要是小写而不是大写，以利用全文倒排索引定位数据行。注意空白字符分词不执行小写转换，因此查询区分大小写（例如，`"Hello"` 和 `"hello"` 是不同的标记）。
 
     ```SQL
     MySQL [example_db]> INSERT INTO t VALUES (3, "StarRocks is the BEST");

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
@@ -61,6 +61,12 @@ public class InvertedIndexUtil {
      */
     public static String INVERTED_INDEX_PARSER_CHINESE = "chinese";
 
+    /**
+     * Parse value with the WhitespaceAnalyzer, which splits text into tokens at whitespace characters only,
+     * preserving punctuation and special characters within tokens. Does not perform lowercasing.
+     */
+    public static String INVERTED_INDEX_PARSER_WHITESPACE = "whitespace";
+
     public static String getInvertedIndexParser(Map<String, String> properties) {
         String parser = properties == null ? null : properties.get(INVERTED_INDEX_PARSER_KEY);
         // default is "none" if not set
@@ -120,7 +126,8 @@ public class InvertedIndexUtil {
             if (!(parser.equals(INVERTED_INDEX_PARSER_NONE)
                     || parser.equals(INVERTED_INDEX_PARSER_STANDARD)
                     || parser.equals(INVERTED_INDEX_PARSER_ENGLISH)
-                    || parser.equals(INVERTED_INDEX_PARSER_CHINESE))) {
+                    || parser.equals(INVERTED_INDEX_PARSER_CHINESE)
+                    || parser.equals(INVERTED_INDEX_PARSER_WHITESPACE))) {
                 throw new SemanticException("INVERTED index parser: " + parser
                         + " is invalid for column: " + indexColName + " of type " + colType);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -115,6 +115,12 @@ public class GINIndexTest extends PlanTestBase {
                     put(SearchParamsKey.RERANK.name().toLowerCase(Locale.ROOT), "false");
                 }}, KeysType.DUP_KEYS));
 
+        Assertions.assertDoesNotThrow(
+                () -> InvertedIndexUtil.checkInvertedIndexValid(c2, new HashMap<String, String>() {{
+                    put(IMP_LIB.name().toLowerCase(Locale.ROOT), InvertedIndexImpType.CLUCENE.name());
+                    put(InvertedIndexUtil.INVERTED_INDEX_PARSER_KEY, InvertedIndexUtil.INVERTED_INDEX_PARSER_WHITESPACE);
+                }}, KeysType.DUP_KEYS));
+
         new MockUp<RunMode>() {
             @Mock
             public boolean isSharedDataMode() {

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1689,3 +1689,70 @@ SELECT sleep(10);
 DROP TABLE t_vertical_compaction;
 -- result:
 -- !result
+-- name: test_gin_index_single_predicate_whitespace
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+-- result:
+-- !result
+set low_cardinality_optimize_v2 = false;
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+CREATE TABLE `t_gin_index_single_predicate_whitespace` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_whitespace (`text_column`) USING GIN ("parser" = "whitespace") COMMENT 'whitespace index'
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_gin_index_single_predicate_whitespace VALUES
+(1, "user-john@email.com hello world"),
+(2, "john smith 12345"),
+(3, "Hello World"),
+(4, "hello-world test"),
+(5, NULL);
+-- result:
+-- !result
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "john";
+-- result:
+2	john smith 12345
+-- !result
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "user-john@email.com";
+-- result:
+1	user-john@email.com hello world
+-- !result
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "hello";
+-- result:
+1	user-john@email.com hello world
+-- !result
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "Hello";
+-- result:
+3	Hello World
+-- !result
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "hello-world";
+-- result:
+4	hello-world test
+-- !result
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "world";
+-- result:
+1	user-john@email.com hello world
+-- !result
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column not match "hello";
+-- result:
+2	john smith 12345
+3	Hello World
+4	hello-world test
+5	None
+-- !result
+DROP TABLE t_gin_index_single_predicate_whitespace;
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -930,3 +930,38 @@ ALTER TABLE t_vertical_compaction BASE COMPACT;
 SELECT sleep(10);
 
 DROP TABLE t_vertical_compaction;
+
+-- name: test_gin_index_single_predicate_whitespace
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+set low_cardinality_optimize_v2 = false;
+set cbo_enable_low_cardinality_optimize = false;
+CREATE TABLE `t_gin_index_single_predicate_whitespace` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_whitespace (`text_column`) USING GIN ("parser" = "whitespace") COMMENT 'whitespace index'
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_gin_index_single_predicate_whitespace VALUES
+(1, "user-john@email.com hello world"),
+(2, "john smith 12345"),
+(3, "Hello World"),
+(4, "hello-world test"),
+(5, NULL);
+
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "john";
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "user-john@email.com";
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "hello";
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "Hello";
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "hello-world";
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column match "world";
+SELECT * FROM t_gin_index_single_predicate_whitespace WHERE text_column not match "hello";
+
+DROP TABLE t_gin_index_single_predicate_whitespace;


### PR DESCRIPTION
## Why I'm doing:

The current GIN inverted index parsers (none, standard, english, chinese) don't offer a way to tokenize text purely by whitespace. This means strings like `user-john@email.com` get split at punctuation, making it impossible to search for them as whole tokens. A whitespace parser fills this gap by preserving punctuation and special characters within tokens.

This is a well-established tokenizer in the search ecosystem. Apache Lucene, Apache Solr, Elasticsearch/OpenSearch, and Apache Doris all provide a `WhitespaceAnalyzer`/`whitespace` tokenizer with the same semantics.

## What I'm doing:

Add a new `"whitespace"` parser option for GIN inverted index that uses CLucene's `WhitespaceAnalyzer`. It splits text into tokens only at whitespace characters, preserving punctuation, special characters, and case sensitivity.

Usage:
```sql
CREATE TABLE t (
    id BIGINT,
    text VARCHAR(500),
    INDEX idx (text) USING GIN ("parser" = "whitespace")
) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id);
```

Changes:
- BE: Added `PARSER_WHITESPACE` enum, string constants, analyzer init, and tokenized write path
- FE: Added parser constant and validation acceptance in `InvertedIndexUtil.java`
- Tests: FE unit test and SQL integration test covering case-sensitivity, punctuation preservation, and NOT MATCH

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
