### PR TITLE
VSS-213: Add support for configurable LDAP group search pagination (ldap_search_page_size)

### DIFF
--- a/docs/en/administration/user_privs/group_provider.md
+++ b/docs/en/administration/user_privs/group_provider.md
@@ -60,7 +60,8 @@ ldap_info ::=
 ldap_search_group_arg ::= 
     { "ldap_group_dn" = "" 
     | "ldap_group_filter" = "" }, 
-    "ldap_group_identifier_attr" = ""
+    "ldap_group_identifier_attr" = "",
+    "ldap_search_page_size"=""
 
 ldap_search_user_arg ::=
     "ldap_group_member_attr" = "",
@@ -135,6 +136,10 @@ A customized group filter that can be recognized by the LDAP server. It will be 
 ##### `ldap_group_identifier_attr`
 
 The attribute used as the identifier for the group name.
+
+##### `ldap_search_page_size`
+
+Optional. Configures the number of LDAP entries fetched per page during group search operations. Default: No paging
 
 #### `ldap_search_user_arg` parameter group
 

--- a/docs/en/best_practices/authentication_authorization.md
+++ b/docs/en/best_practices/authentication_authorization.md
@@ -193,7 +193,8 @@ The following example is based on LDAP.
    ldap_search_group_arg ::= 
        { "ldap_group_dn" = "" 
        | "ldap_group_filter" = "" }, 
-       "ldap_group_identifier_attr" = ""
+       "ldap_group_identifier_attr" = "",
+       "ldap_search_page_size"=""
    
    ldap_search_user_arg ::=
        "ldap_group_member_attr" = "",

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
@@ -47,10 +47,13 @@ import javax.naming.NamingException;
 import javax.naming.PartialResultException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
-import javax.naming.directory.DirContext;
-import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.PagedResultsControl;
+import javax.naming.ldap.PagedResultsResponseControl;
 import javax.net.ssl.SSLContext;
 
 public class LDAPGroupProvider extends GroupProvider {
@@ -95,6 +98,11 @@ public class LDAPGroupProvider extends GroupProvider {
      * Control the refresh frequency of ldap group
      */
     public static final String LDAP_CACHE_REFRESH_INTERVAL = "ldap_cache_refresh_interval";
+
+    /**
+     * Control the search page size
+     */
+    public static final String LDAP_SEARCH_PAGE_SIZE = "ldap_search_page_size";
 
     public static final Set<String> REQUIRED_PROPERTIES = new HashSet<>(Arrays.asList(
             LDAP_LDAP_CONN_URL,
@@ -146,23 +154,44 @@ public class LDAPGroupProvider extends GroupProvider {
     public void refreshGroups() {
         LOG.info("refresh ldap group cache for group provider: {}", name);
         Map<String, Set<String>> groups = new ConcurrentHashMap<>();
+        LdapContext ctx = null;
+
         try {
-            DirContext ctx = createDirContextOnConnection(getLdapBindRootDn(), getLdapBindRootPwd());
+            ctx = createDirContextOnConnection(getLdapBindRootDn(), getLdapBindRootPwd());
             UserNameExtractInterface userNameExtractInterface = getUserNameExtractInterface();
 
             if (getLdapGroupFilter() != null) {
                 SearchControls searchControls = new SearchControls();
                 searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
-                NamingEnumeration<SearchResult> results = ctx.search(getLdapBaseDn(), getLdapGroupFilter(), searchControls);
-                try {
-                    while (results.hasMore()) {
-                        SearchResult result = results.next();
-                        Attributes attributes = result.getAttributes();
-                        matchUserAndUpdateGroups(groups, attributes, userNameExtractInterface);
+
+                byte[] cookie = null;
+                Optional<Integer> pageSize = getLdapSearchPageSize();
+
+                do {
+                    if (pageSize.isPresent()) {
+                        ctx.setRequestControls(new Control[] {
+                            new PagedResultsControl(pageSize.get(), cookie, Control.NONCRITICAL)
+                        });
                     }
-                } catch (PartialResultException e) {
-                    LOG.warn("LDAP group search partial result exception", e);
-                }
+
+                    NamingEnumeration<SearchResult> results = ctx.search(getLdapBaseDn(), getLdapGroupFilter(), searchControls);
+
+                    try {
+                        while (results.hasMoreElements()) {
+                            SearchResult result = results.next();
+                            Attributes attributes = result.getAttributes();
+                            matchUserAndUpdateGroups(groups, attributes, userNameExtractInterface);
+                        }
+                    } catch (PartialResultException e) {
+                        LOG.warn("LDAP group search partial result exception; stoping paging", e);
+                        break; // safer to stop paging here
+                    } finally {
+                        if (results != null) {
+                            results.close();
+                        }
+                    }
+                    cookie = getResponseCookie(ctx.getResponseControls());
+                } while (cookie != null && cookie.length > 0);
             } else if (getLdapGroupDn() != null) {
                 for (String ldapGroupDN : getLdapGroupDn()) {
                     Attributes attributes =
@@ -175,6 +204,14 @@ public class LDAPGroupProvider extends GroupProvider {
         } catch (Exception e) {
             //Do not affect the normal login process at this time. If an error occurs, an empty group will be returned.
             LOG.error("LDAP group search failed", e);
+        } finally {
+            if (ctx != null) {
+                try {
+                    ctx.close();
+                } catch (Exception e) {
+                    LOG.warn("Exception while closing context", e);
+                }
+            }
         }
 
         if (LOG.isDebugEnabled()) {
@@ -182,6 +219,19 @@ public class LDAPGroupProvider extends GroupProvider {
         }
 
         this.userToGroupCache = groups;
+    }
+
+    private byte[] getResponseCookie(final Control[] controls) {
+        if (controls != null) {
+            for (Control control : controls) {
+                if (control instanceof PagedResultsResponseControl) {
+                    PagedResultsResponseControl pagedControl = (PagedResultsResponseControl) control;
+                    return pagedControl.getCookie();
+                }
+            }
+        }
+
+        return null;
     }
 
     private void matchUserAndUpdateGroups(Map<String, Set<String>> groups,
@@ -289,7 +339,7 @@ public class LDAPGroupProvider extends GroupProvider {
         }
     }
 
-    public DirContext createDirContextOnConnection(String dn, String pwd) throws NamingException, IOException,
+    public LdapContext createDirContextOnConnection(String dn, String pwd) throws NamingException, IOException,
             GeneralSecurityException {
         if (Strings.isNullOrEmpty(pwd)) {
             LOG.warn("empty password is not allowed for simple authentication");
@@ -320,7 +370,7 @@ public class LDAPGroupProvider extends GroupProvider {
             environment.put("java.naming.ldap.factory.socket", LdapSslSocketFactory.class.getName());
         }
 
-        return new InitialDirContext(environment);
+        return new InitialLdapContext(environment, null);
     }
 
     public String getLdapConnUrl() {
@@ -385,6 +435,10 @@ public class LDAPGroupProvider extends GroupProvider {
 
     public Long getLdapCacheRefreshInterval() {
         return Long.parseLong(properties.getOrDefault(LDAP_CACHE_REFRESH_INTERVAL, "300"));
+    }
+
+    public Optional<Integer> getLdapSearchPageSize() {
+        return Optional.ofNullable(properties.get(LDAP_SEARCH_PAGE_SIZE)).map(Integer::parseInt);
     }
 
     private void validateIntegerProp(Map<String, String> propertyMap, String key, int min, int max)


### PR DESCRIPTION
This PR introduces support for configurable pagination when querying LDAP groups using the `ldap_search_page_size` parameter.

## Why I'm doing:
Previously, LDAP group searches were executed without paging, which could lead to incomplete results (due to server-side limits) or large response payloads. With this change, group searches can be performed using paged results, improving scalability and reliability for large directories.

## What I'm doing:
Add support for configurable LDAP group search pagination (ldap_search_page_size)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5
  - [ ] 3.4
