### PR TITLE
feat: Add HTTPS support for BE/CN HTTP server ports (backport to 3.5.17)

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -262,6 +262,9 @@ include_directories(${Poco_INCLUDE_DIRS})
 add_library(libevent STATIC IMPORTED)
 set_target_properties(libevent PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libevent.a)
 
+add_library(libevent_openssl STATIC IMPORTED)
+set_target_properties(libevent_openssl PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libevent_openssl.a)
+
 add_library(openssl STATIC IMPORTED)
 set_target_properties(openssl PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libssl.a)
 
@@ -924,6 +927,7 @@ set(STARROCKS_DEPENDENCIES
     # Otherwise, he will use the lz4 Library in librdkafka
     lz4
     libevent
+    libevent_openssl
     curl
     ${Poco_LIBRARIES}
     libz

--- a/be/src/http/ev_http_server.h
+++ b/be/src/http/ev_http_server.h
@@ -15,9 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#ifndef EVENT_HAVE_OPENSSL
+#define EVENT_HAVE_OPENSSL
+#endif
 #pragma once
 
 #include <event2/event.h>
+#include <openssl/ssl.h>
+#include <event2/bufferevent_ssl.h>
 
 #include <string>
 #include <thread>
@@ -56,6 +61,8 @@ public:
 private:
     Status _bind();
     HttpHandler* _find_handler(HttpRequest* req);
+    void _Init();
+    int _ServerSetCerts();
 
 private:
     // input param
@@ -79,6 +86,8 @@ private:
     PathTrie<HttpHandler*> _options_handlers;
     std::vector<struct event_base*> _event_bases;
     std::vector<struct evhttp*> _https;
+    SSL_CTX* m_ctx;
+    EC_KEY* m_ecdh;
 };
 
 } // namespace starrocks

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -172,14 +172,19 @@ check_if_archieve_exist() {
 build_libevent() {
     check_if_source_exist $LIBEVENT_SOURCE
     cd $TP_SOURCE_DIR/$LIBEVENT_SOURCE
-    if [ ! -f configure ]; then
-        ./autogen.sh
-    fi
 
-    LDFLAGS="-L${TP_LIB_DIR}" \
-    ./configure --prefix=$TP_INSTALL_DIR --enable-shared=no --disable-samples --disable-libevent-regress
-    make -j$PARALLEL
-    make install
+    mkdir -p ${BUILD_DIR}
+    cd ${BUILD_DIR}
+    CFLAGS="-std=c99 -D_BSD_SOURCE -fno-omit-frame-pointer -g -ggdb -O2 -I${TP_INCLUDE_DIR}" \
+	    CPPFLAGS="-I${TP_INCLUDE_DIR}" \
+	    LDFLAGS="-L${TP_LIB_DIR}" \
+	    ${CMAKE_CMD} -G "${CMAKE_GENERATOR}" -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" -DEVENT__DISABLE_TESTS=ON \
+            -DEVENT__DISABLE_OPENSSL=OFF -DEVENT__DISABLE_SAMPLES=ON -DEVENT__DISABLE_REGRESS=ON \
+	    -DOPENSSL_ROOT_DIR=${TP_LIB_DIR} -DOPENSSL_INCLUDE_DIR=${TP_INCLUDE_DIR} \
+	    -DOPENSSL_CRYPTO_LIBRARY="${TP_LIB_DIR}/libcrypto.a" -DOPENSSL_SSL_LIBRARY="${TP_LIB_DIR}/libssl.a" ..
+
+    ${BUILD_SYSTEM} -j$PARALLEL
+    ${BUILD_SYSTEM} install
 }
 
 build_openssl() {
@@ -1460,12 +1465,12 @@ export CXXFLAGS=$GLOBAL_CXXFLAGS
 export CFLAGS=$GLOBAL_CFLAGS
 
 
-build_libevent
 build_zlib
 build_lz4
 build_lzo2
 build_bzip
 build_openssl
+build_libevent # must build after openssl
 build_boost # must before thrift
 build_protobuf
 build_gflags


### PR DESCRIPTION
## Why I'm doing:

Complete HTTPS support for StarRocks 3.5.11-deepbi1 by adding SSL/TLS encryption to BE/CN HTTP server ports. This complements the existing FE HTTPS support and provides end-to-end encrypted communication.

## What I'm doing:

Backported upstream PR #62377 to branch-3.5.11, adding HTTPS support for BE/CN HTTP server ports. Changes include:

- Added three new BE configuration options:
  - `enable_https` - Enable/disable HTTPS for BE HTTP server (default: false)
  - `ssl_certificate_path` - Path to SSL certificate file (PEM format)
  - `ssl_private_key_path` - Path to SSL private key file (PEM format)

- Modified HTTP server to use OpenSSL/libevent for TLS encryption
- Updated thirdparty build to compile libevent with OpenSSL support
- Added helper script `rebuild_libevent_with_ssl.sh` for Docker container development workflow

Tested with self-signed certificates - verified TLS 1.3 handshake, strong cipher suites, and all BE endpoints working over HTTPS.

Fixes #62377

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
